### PR TITLE
Try using fancy environment modification features.

### DIFF
--- a/cmake/modules/FindSwiftXCTest.cmake
+++ b/cmake/modules/FindSwiftXCTest.cmake
@@ -141,12 +141,9 @@ function(add_swift_xctest test_target testee)
     add_test(NAME ${test_target}
       COMMAND ${test_target})
 
-    # When $ENV{PATH} is interpreted as a list on Windows, trailing backslashes in elements
-    # (e.g. "C:\path\to\foo\;C:\another\path\...") will end up causing semicolons to be escaped.
-    string(REPLACE "\\" "/" path "$ENV{PATH}")
-
     set_tests_properties(${test_target}
       PROPERTIES ENVIRONMENT_MODIFICATION
+      # For each DLL dependency X, make the PATH=path_list_prepend:X environment modification.
       "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:${test_target}>,PREPEND,PATH=path_list_prepend:>")
 
   endif()

--- a/cmake/modules/FindSwiftXCTest.cmake
+++ b/cmake/modules/FindSwiftXCTest.cmake
@@ -127,7 +127,7 @@ function(add_swift_xctest test_target testee)
       # or they won't be found and the target will fail to run, so invoke it through cmake.  Because
       COMMAND ${CMAKE_COMMAND} -E env
         $<$<LIST:LENGTH,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>>:--modify>
-        "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>,PREPEND,PATH=>"
+        "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>,PREPEND,PATH=path_list_prepend:>"
         --
         $<TARGET_FILE:GenerateXCTestMain> -o ${test_main} ${sources}
       DEPENDS ${sources} GenerateXCTestMain
@@ -147,7 +147,7 @@ function(add_swift_xctest test_target testee)
 
     set_tests_properties(${test_target}
       PROPERTIES ENVIRONMENT_MODIFICATION
-      "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:${test_target}>,PREPEND,PATH=>")
+      "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:${test_target}>,PREPEND,PATH=path_list_prepend:>")
 
   endif()
 

--- a/cmake/modules/FindSwiftXCTest.cmake
+++ b/cmake/modules/FindSwiftXCTest.cmake
@@ -126,8 +126,8 @@ function(add_swift_xctest test_target testee)
       # If the executable target depends on DLLs their directories need to be injected into the PATH
       # or they won't be found and the target will fail to run, so invoke it through cmake.  Because
       COMMAND
-        ${CMAKE_COMMAND} -E env
-        "PATH=$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>;$ENV{PATH},;>"
+        ${CMAKE_COMMAND} -E env --modify
+        "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>,PREPEND,PATH=>"
         --
         $<TARGET_FILE:GenerateXCTestMain> -o ${test_main} ${sources}
       DEPENDS ${sources} GenerateXCTestMain
@@ -145,12 +145,9 @@ function(add_swift_xctest test_target testee)
     # (e.g. "C:\path\to\foo\;C:\another\path\...") will end up causing semicolons to be escaped.
     string(REPLACE "\\" "/" path "$ENV{PATH}")
 
-    # Escape the semicolons when forming the environment setting.  As explained in
-    # https://stackoverflow.com/a/59866840/125349, “this is not the last place the list will be used
-    # (and interpreted by CMake). [It] is then used to populate CTestTestfile.cmake, which is later
-    # read by CTest to setup your test environment.”
     set_tests_properties(${test_target}
-      PROPERTIES ENVIRONMENT "PATH=$<JOIN:$<TARGET_RUNTIME_DLL_DIRS:${test_target}>;${path},\\;>")
+      PROPERTIES ENVIRONMENT_MODIFICATION
+      "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:${test_target}>,PREPEND,PATH=>")
 
   endif()
 

--- a/cmake/modules/FindSwiftXCTest.cmake
+++ b/cmake/modules/FindSwiftXCTest.cmake
@@ -125,8 +125,8 @@ function(add_swift_xctest test_target testee)
       OUTPUT ${test_main}
       # If the executable target depends on DLLs their directories need to be injected into the PATH
       # or they won't be found and the target will fail to run, so invoke it through cmake.  Because
-      COMMAND
-        ${CMAKE_COMMAND} -E env --modify
+      COMMAND ${CMAKE_COMMAND} -E env
+        $<$<LIST:LENGTH,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>>:--modify>
         "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>,PREPEND,PATH=>"
         --
         $<TARGET_FILE:GenerateXCTestMain> -o ${test_main} ${sources}

--- a/cmake/modules/FindSwiftXCTest.cmake
+++ b/cmake/modules/FindSwiftXCTest.cmake
@@ -125,9 +125,9 @@ function(add_swift_xctest test_target testee)
       OUTPUT ${test_main}
       # If the executable target depends on DLLs their directories need to be injected into the PATH
       # or they won't be found and the target will fail to run, so invoke it through cmake.  Because
-      COMMAND ${CMAKE_COMMAND} -E env
-        $<$<LIST:LENGTH,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>>:--modify>
-        "$<LIST:TRANSFORM,$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>,PREPEND,PATH=path_list_prepend:>"
+      COMMAND
+        ${CMAKE_COMMAND} -E env
+        "PATH=$<SHELL_PATH:$<TARGET_RUNTIME_DLL_DIRS:GenerateXCTestMain>;$ENV{PATH}>"
         --
         $<TARGET_FILE:GenerateXCTestMain> -o ${test_main} ${sources}
       DEPENDS ${sources} GenerateXCTestMain


### PR DESCRIPTION
Clearly a win for the second case.  Not so much for the first.  Switched to `SHELL_PATH` for clarity.

https://discourse.cmake.org/t/variables-for-cross-platform-code/10115/8